### PR TITLE
Speed test memory array too short

### DIFF
--- a/examples/speed.html
+++ b/examples/speed.html
@@ -6,7 +6,7 @@
     
         <script>
             document.body.innerHTML="running speed test..."
-            var mem = new Uint8Array(0xFFFF);
+            var mem = new Uint8Array(0x10000);
             var cpu = new CPU6502.CPU6502();
 
             cpu.read = function(addr) {


### PR DESCRIPTION
This fixes a simple off-by-one error in memory array creation.