### PR TITLE
Fixed indirect JMP

### DIFF
--- a/src/cpu.js
+++ b/src/cpu.js
@@ -101,11 +101,11 @@ class CPU6502{
     }
 
     ind() {
-	    var a = this.read(this.PC);
-	    a |= this.read( (this.PC & 0xFF00) | ((this.PC + 1) & 0xFF) ) << 8;
+	    var a = this.read(this.PC++);
+	    a |= (this.read(this.PC++) << 8);
 	    this.addr = this.read(a);
-	    this.addr |= (this.read(a+1) << 8);
-	    this.cycles += 5;
+	    this.addr |= (this.read( (a & 0xFF00) | ((a + 1) & 0xFF) ) << 8);
+	    this.cycles += 6;
     }
 
     zp() {


### PR DESCRIPTION
It looks like an attempt was made to handle the "6502 Jump Bug" but it wasn't done quite right. This change implements the bug correctly.

The number of cycles has also been adjusted to counter the cycle-- decrement in the jmp() function.